### PR TITLE
Abstract _BaseNode class with add_node()

### DIFF
--- a/sphinx_carousel/carousel.py
+++ b/sphinx_carousel/carousel.py
@@ -13,8 +13,7 @@ from docutils.nodes import Element, image as docutils_image
 from docutils.parsers.rst import Directive, directives
 from sphinx.application import Sphinx
 
-from sphinx_carousel import __version__
-from sphinx_carousel.nodes import CarouselControlNode, CarouselInnerNode, CarouselItemNode, CarouselSlideNode
+from sphinx_carousel import __version__, nodes
 
 
 class Carousel(Directive):
@@ -43,17 +42,17 @@ class Carousel(Directive):
         items = []
         for idx, image in enumerate(self.images()):
             image["classes"] += ["d-block", "w-100"]
-            items.append(CarouselItemNode(idx == 0, "", image))
-        inner_div = CarouselInnerNode("", *items)
+            items.append(nodes.CarouselItemNode(idx == 0, "", image))
+        inner_div = nodes.CarouselInnerNode("", *items)
         child_nodes.append(inner_div)
 
         # Build control buttons.
         if "no_controls" not in self.options:
-            buttons = [CarouselControlNode(div_id, prev=True), CarouselControlNode(div_id)]
+            buttons = [nodes.CarouselControlNode(div_id, prev=True), nodes.CarouselControlNode(div_id)]
             child_nodes.extend(buttons)
 
         data_ride = "" if "no_data_ride" in self.options else "carousel"
-        main_div = CarouselSlideNode(div_id, data_ride, "", *child_nodes)
+        main_div = nodes.CarouselSlideNode(div_id, data_ride, "", *child_nodes)
         return [main_div]
 
 
@@ -86,9 +85,9 @@ def setup(app: Sphinx) -> Dict[str, str]:
     """
     app.add_config_value("carousel_add_bootstrap_css_js", True, "html")
     app.add_directive("carousel", Carousel)
-    app.add_node(CarouselControlNode, html=(CarouselControlNode.html_visit, CarouselControlNode.html_depart))
-    app.add_node(CarouselInnerNode, html=(CarouselInnerNode.html_visit, CarouselInnerNode.html_depart))
-    app.add_node(CarouselItemNode, html=(CarouselItemNode.html_visit, CarouselItemNode.html_depart))
-    app.add_node(CarouselSlideNode, html=(CarouselSlideNode.html_visit, CarouselSlideNode.html_depart))
+    nodes.CarouselControlNode.add_node(app)
+    nodes.CarouselInnerNode.add_node(app)
+    nodes.CarouselItemNode.add_node(app)
+    nodes.CarouselSlideNode.add_node(app)
     app.connect("builder-inited", add_static)
     return dict(version=__version__)

--- a/sphinx_carousel/nodes.py
+++ b/sphinx_carousel/nodes.py
@@ -1,10 +1,34 @@
 """Docutils nodes."""
 # pylint: disable=keyword-arg-before-vararg
+from abc import abstractmethod
+
 from docutils import nodes
+from sphinx.application import Sphinx
 from sphinx.writers.html5 import HTML5Translator
 
 
-class CarouselSlideNode(nodes.Element):
+class _BaseNode(nodes.Element):
+    """Base node class."""
+
+    @staticmethod
+    @abstractmethod
+    def html_visit(writer: HTML5Translator, node: "_BaseNode"):
+        """Append opening tags to document body list."""
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def html_depart(writer: HTML5Translator, _):
+        """Append closing tags to document body list."""
+        raise NotImplementedError
+
+    @classmethod
+    def add_node(cls, app: Sphinx):
+        """Convenience method that adds the subclass node to the Sphinx app.."""
+        app.add_node(cls, html=(cls.html_visit, cls.html_depart))
+
+
+class CarouselSlideNode(_BaseNode):
     """Main div."""
 
     def __init__(self, div_id: str, data_ride: str = "", rawsource: str = "", *children, **attributes):
@@ -34,7 +58,7 @@ class CarouselSlideNode(nodes.Element):
         writer.body.append("</div>")
 
 
-class CarouselInnerNode(nodes.Element):
+class CarouselInnerNode(_BaseNode):
     """Secondary div that contains the image divs."""
 
     @staticmethod
@@ -48,7 +72,7 @@ class CarouselInnerNode(nodes.Element):
         writer.body.append("</div>")
 
 
-class CarouselItemNode(nodes.Element):
+class CarouselItemNode(_BaseNode):
     """Div that contains an image."""
 
     def __init__(self, active: bool, rawsource="", *children, **attributes):
@@ -76,7 +100,7 @@ class CarouselItemNode(nodes.Element):
         writer.body.append("</div>")
 
 
-class CarouselControlNode(nodes.Element):
+class CarouselControlNode(_BaseNode):
     """Previous/next buttons."""
 
     def __init__(self, div_id: str, prev: bool = False, rawsource: str = "", *children, **attributes):


### PR DESCRIPTION
Creating abstract middle class that implements `add_node()`. Use this
instead of Sphinx_app.add_node directly.

Importing nodes module instead of each node class for style. Line was
getting long.