### PR TITLE
pytest fixture, test_controls split, fix sr-only

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,10 +5,13 @@ Usage
 =====
 
 .. carousel::
+    :show_controls:
 
     .. image:: https://i.imgur.com/fmJnevTl.jpg
     .. image:: https://i.imgur.com/ppGH90Jl.jpg
     .. image:: https://i.imgur.com/fWyn9A2l.jpg
+
+TODO update below.
 
 .. tabbed:: reStructuredText
 

--- a/sphinx_carousel/nodes.py
+++ b/sphinx_carousel/nodes.py
@@ -132,7 +132,8 @@ class CarouselControlNode(BaseNode):
         }
         writer.body.append(writer.starttag(node, "span", "", **attributes_span))
         writer.body.append("</span>")
-        writer.body.append(writer.starttag(node, "span", "", **{"sr-only": "Previous" if node.prev else "Next"}))
+        writer.body.append(writer.starttag(node, "span", "", **{"CLASS": "sr-only"}))
+        writer.body.append("Previous" if node.prev else "Next")
         writer.body.append("</span>")
 
     @staticmethod

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,8 +1,9 @@
 """pytest fixtures."""
 from pathlib import Path
+from typing import List
 
 import pytest
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, element
 from sphinx.testing.path import path
 from sphinx.testing.util import SphinxTestApp
 
@@ -27,3 +28,9 @@ def _index_html(sphinx_app: SphinxTestApp) -> BeautifulSoup:
     """Read and parse generated test index.html."""
     text = (Path(sphinx_app.outdir) / "index.html").read_text(encoding="utf8")
     return BeautifulSoup(text, "html.parser")
+
+
+@pytest.fixture()
+def carousels(index_html: BeautifulSoup) -> List[element.Tag]:
+    """Return all top-level carousels in index.html."""
+    return index_html.find_all("div", ["carousel", "slide"])

--- a/tests/unit_tests/test_controls.py
+++ b/tests/unit_tests/test_controls.py
@@ -1,38 +1,62 @@
 """Tests."""
+from typing import List
+
 import pytest
-from bs4 import BeautifulSoup
+from bs4 import element
 
 
 @pytest.mark.sphinx("html", testroot="controls")
-def test(index_html: BeautifulSoup):
+def test(carousels: List[element.Tag]):
     """Test."""
-    carousel = list(index_html.find_all("div", ["carousel", "slide"])[0])
-    assert carousel[0]["class"] == ["carousel-inner"]
-    assert len(carousel) == 1
+    carousel = list(carousels[0])
 
-    carousel = list(index_html.find_all("div", ["carousel", "slide"])[1])
     assert carousel[0]["class"] == ["carousel-inner"]
-    assert len(carousel) == 1
 
-    carousel = list(index_html.find_all("div", ["carousel", "slide"])[2])
+    assert carousel[1]["class"] == ["carousel-control-prev"]
+    assert carousel[1]["data-slide"] == "prev"
+    spans = list(carousel[1])
+    assert spans[0]["class"] == ["carousel-control-prev-icon"]
+    assert spans[1]["class"] == ["sr-only"]
+    assert spans[1].text == "Previous"
+
+    assert carousel[2]["class"] == ["carousel-control-next"]
+    assert carousel[2]["data-slide"] == "next"
+    spans = list(carousel[2])
+    assert spans[0]["class"] == ["carousel-control-next-icon"]
+    assert spans[1]["class"] == ["sr-only"]
+    assert spans[1].text == "Next"
+
+
+@pytest.mark.sphinx("html", testroot="controls")
+def test_toggle(carousels: List[element.Tag]):
+    """Test."""
+    carousel = list(carousels[0])
     assert carousel[0]["class"] == ["carousel-inner"]
     assert carousel[1]["class"] == ["carousel-control-prev"]
     assert carousel[2]["class"] == ["carousel-control-next"]
+
+    carousel = list(carousels[1])
+    assert carousel[0]["class"] == ["carousel-inner"]
+    assert len(carousel) == 1
+
+    carousel = list(carousels[2])
+    assert carousel[0]["class"] == ["carousel-inner"]
+    assert len(carousel) == 1
 
 
 @pytest.mark.sphinx("html", testroot="controls-conf")
-def test_conf(index_html: BeautifulSoup):
+def test_toggle_conf(carousels: List[element.Tag]):
     """Test."""
-    carousel = list(index_html.find_all("div", ["carousel", "slide"])[0])
+    carousel = list(carousels[0])
     assert carousel[0]["class"] == ["carousel-inner"]
     assert carousel[1]["class"] == ["carousel-control-prev"]
     assert carousel[2]["class"] == ["carousel-control-next"]
 
-    carousel = list(index_html.find_all("div", ["carousel", "slide"])[1])
+    carousel = list(carousels[1])
     assert carousel[0]["class"] == ["carousel-inner"]
     assert len(carousel) == 1
 
-    carousel = list(index_html.find_all("div", ["carousel", "slide"])[2])
+    carousel = list(carousels[2])
     assert carousel[0]["class"] == ["carousel-inner"]
     assert carousel[1]["class"] == ["carousel-control-prev"]
     assert carousel[2]["class"] == ["carousel-control-next"]

--- a/tests/unit_tests/test_docs/test-controls-conf/index.rst
+++ b/tests/unit_tests/test_docs/test-controls-conf/index.rst
@@ -1,4 +1,5 @@
 .. carousel::
+    :show_controls:
 
     .. image:: https://i.imgur.com/fmJnevTl.jpg
     .. image:: https://i.imgur.com/ppGH90Jl.jpg
@@ -14,7 +15,6 @@
 
 
 .. carousel::
-    :show_controls:
 
     .. image:: https://i.imgur.com/fmJnevTl.jpg
     .. image:: https://i.imgur.com/ppGH90Jl.jpg

--- a/tests/unit_tests/test_docs/test-controls/index.rst
+++ b/tests/unit_tests/test_docs/test-controls/index.rst
@@ -1,4 +1,5 @@
 .. carousel::
+    :show_controls:
 
     .. image:: https://i.imgur.com/fmJnevTl.jpg
     .. image:: https://i.imgur.com/ppGH90Jl.jpg
@@ -14,7 +15,6 @@
 
 
 .. carousel::
-    :show_controls:
 
     .. image:: https://i.imgur.com/fmJnevTl.jpg
     .. image:: https://i.imgur.com/ppGH90Jl.jpg

--- a/tests/unit_tests/test_external_image.py
+++ b/tests/unit_tests/test_external_image.py
@@ -1,10 +1,12 @@
 """Tests."""
+from typing import List
+
 import pytest
-from bs4 import BeautifulSoup
+from bs4 import element
 
 
 @pytest.mark.sphinx("html", testroot="external-image")
-def test(index_html: BeautifulSoup):
+def test(carousels: List[element.Tag]):
     """Test.
 
     <div class="carousel slide" data-ride="carousel">
@@ -21,7 +23,7 @@ def test(index_html: BeautifulSoup):
       </div>
     </div>
     """
-    carousel_slide = index_html.find_all("div", ["carousel", "slide"])[0]
+    carousel_slide = carousels[0]
     carousel_inner = carousel_slide.find_all("div", ["carousel-inner"])[0]
     carousel_items = carousel_inner.find_all("div", ["carousel-item"])
 

--- a/tests/unit_tests/test_id_data_ride.py
+++ b/tests/unit_tests/test_id_data_ride.py
@@ -1,10 +1,12 @@
 """Tests."""
+from typing import List
+
 import pytest
-from bs4 import BeautifulSoup
+from bs4 import element
 
 
 @pytest.mark.sphinx("html", testroot="id-data-ride")
-def test_id(index_html: BeautifulSoup):
+def test_id(carousels: List[element.Tag]):
     """Test.
 
     <div id="customId" class="carousel slide" data-ride="carousel">
@@ -15,7 +17,7 @@ def test_id(index_html: BeautifulSoup):
       </div>
     </div>
     """
-    carousel_slide = index_html.find_all("div", ["carousel", "slide"])[0]
+    carousel_slide = carousels[0]
     assert carousel_slide.has_attr("id")
     assert carousel_slide["id"] == "customId"
     assert carousel_slide.has_attr("data-ride")
@@ -32,7 +34,7 @@ def test_id(index_html: BeautifulSoup):
 
 
 @pytest.mark.sphinx("html", testroot="id-data-ride")
-def test_no_data_ride(index_html: BeautifulSoup):
+def test_no_data_ride(carousels: List[element.Tag]):
     """Test.
 
     <div class="carousel slide">
@@ -43,7 +45,7 @@ def test_no_data_ride(index_html: BeautifulSoup):
       </div>
     </div>
     """
-    carousel_slide = index_html.find_all("div", ["carousel", "slide"])[1]
+    carousel_slide = carousels[1]
     assert carousel_slide.has_attr("id")
     assert len(carousel_slide["id"]) == 45
     assert carousel_slide["id"].startswith("carousel-")

--- a/tests/unit_tests/test_image_alt.py
+++ b/tests/unit_tests/test_image_alt.py
@@ -1,10 +1,12 @@
 """Tests."""
+from typing import List
+
 import pytest
-from bs4 import BeautifulSoup
+from bs4 import element
 
 
 @pytest.mark.sphinx("html", testroot="image-alt")
-def test(index_html: BeautifulSoup):
+def test(carousels: List[element.Tag]):
     """Test.
 
     <div class="carousel slide" data-ride="carousel">
@@ -21,7 +23,7 @@ def test(index_html: BeautifulSoup):
       </div>
     </div>
     """
-    carousel_slide = index_html.find_all("div", ["carousel", "slide"])[0]
+    carousel_slide = carousels[0]
     carousel_inner = carousel_slide.find_all("div", ["carousel-inner"])[0]
     carousel_items = carousel_inner.find_all("div", ["carousel-item"])
 

--- a/tests/unit_tests/test_myst.py
+++ b/tests/unit_tests/test_myst.py
@@ -1,12 +1,14 @@
 """Tests."""
+from typing import List
+
 import pytest
-from bs4 import BeautifulSoup
+from bs4 import element
 
 
 @pytest.mark.sphinx("html", testroot="myst")
-def test(index_html: BeautifulSoup):
+def test(carousels: List[element.Tag]):
     """Test."""
-    carousel_slide = index_html.find_all("div", ["carousel", "slide"])[0]
+    carousel_slide = carousels[0]
     carousel_inner = carousel_slide.find_all("div", ["carousel-inner"])[0]
     carousel_items = carousel_inner.find_all("div", ["carousel-item"])
 


### PR DESCRIPTION
Fixing bug: sr-only span was broken.

Using carousels pytest fixture to reduce duplication.

Refactored test_controls to separate toggle tests from tag tests.