### PR TITLE
Conditional on-demand js/css files.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,16 @@ jobs:
             python: "3.10"
           - os: ubuntu-latest
             python: "3.9"
-            sphinx: "3.5.4"
+            sphinx: "4.3.2"
           - os: ubuntu-latest
             python: "3.9"
-            sphinx: "2.4.5"
+            sphinx: "4.2.0"
+          - os: ubuntu-latest
+            python: "3.9"
+            sphinx: "4.1.2"
+          - os: ubuntu-latest
+            python: "3.9"
+            sphinx: "4.0.3"
     runs-on: "${{matrix.os}}"
     steps:
       - {name: Check out repository code, uses: actions/checkout@v2}

--- a/sphinx_carousel/nodes.py
+++ b/sphinx_carousel/nodes.py
@@ -28,7 +28,7 @@ class BaseNode(nodes.Element):
         app.add_node(cls, html=(cls.html_visit, cls.html_depart))
 
 
-class CarouselSlideNode(BaseNode):
+class CarouselMainNode(BaseNode):
     """Main div."""
 
     def __init__(self, div_id: str, data_ride: str = "", rawsource: str = "", *children, **attributes):
@@ -45,7 +45,7 @@ class CarouselSlideNode(BaseNode):
         self.data_ride = data_ride
 
     @staticmethod
-    def html_visit(writer: HTML5Translator, node: "CarouselSlideNode"):
+    def html_visit(writer: HTML5Translator, node: "CarouselMainNode"):
         """Append opening tags to document body list."""
         attributes = {"CLASS": "carousel slide", "ids": [node.div_id]}
         if node.data_ride:

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -30,6 +30,13 @@ def _index_html(sphinx_app: SphinxTestApp) -> BeautifulSoup:
     return BeautifulSoup(text, "html.parser")
 
 
+@pytest.fixture(name="unused_html")
+def _unused_html(sphinx_app: SphinxTestApp) -> BeautifulSoup:
+    """Read and parse generated test unused.html."""
+    text = (Path(sphinx_app.outdir) / "unused.html").read_text(encoding="utf8")
+    return BeautifulSoup(text, "html.parser")
+
+
 @pytest.fixture()
 def carousels(index_html: BeautifulSoup) -> List[element.Tag]:
     """Return all top-level carousels in index.html."""

--- a/tests/unit_tests/test_docs/test-static-off/unused.rst
+++ b/tests/unit_tests/test_docs/test-static-off/unused.rst
@@ -1,0 +1,3 @@
+:orphan:
+
+Unused

--- a/tests/unit_tests/test_docs/test-static-on/unused.rst
+++ b/tests/unit_tests/test_docs/test-static-on/unused.rst
@@ -1,0 +1,3 @@
+:orphan:
+
+Unused

--- a/tests/unit_tests/test_static.py
+++ b/tests/unit_tests/test_static.py
@@ -1,11 +1,19 @@
 """Tests."""
+from pathlib import Path
+
 import pytest
 from bs4 import BeautifulSoup
+from sphinx.testing.util import SphinxTestApp
 
 
 @pytest.mark.sphinx("html", testroot="static-on")
-def test_on(index_html: BeautifulSoup):
+def test_on(sphinx_app: SphinxTestApp, index_html: BeautifulSoup, unused_html: BeautifulSoup):
     """Test."""
+    path_css = Path(sphinx_app.outdir) / "_static" / "bootstrap.min.css"
+    assert path_css.is_file()
+    path_js = Path(sphinx_app.outdir) / "_static" / "bootstrap.min.js"
+    assert path_js.is_file()
+
     link_tags = index_html.find_all("link")
     hrefs = [t.get("href") for t in link_tags]
     assert "_static/bootstrap.min.css" in hrefs
@@ -14,14 +22,33 @@ def test_on(index_html: BeautifulSoup):
     sources = [t.get("src") for t in script_tags]
     assert "_static/bootstrap.min.js" in sources
 
+    link_tags = unused_html.find_all("link")
+    hrefs = [t.get("href") for t in link_tags]
+    assert "_static/bootstrap.min.css" not in hrefs
+    script_tags = unused_html.find_all("script")
+    sources = [t.get("src") for t in script_tags]
+    assert "_static/bootstrap.min.js" not in sources
+
 
 @pytest.mark.sphinx("html", testroot="static-off")
-def test_off(index_html: BeautifulSoup):
+def test_off(sphinx_app: SphinxTestApp, index_html: BeautifulSoup, unused_html: BeautifulSoup):
     """Test."""
+    path_css = Path(sphinx_app.outdir) / "_static" / "bootstrap.min.css"
+    assert not path_css.exists()
+    path_js = Path(sphinx_app.outdir) / "_static" / "bootstrap.min.js"
+    assert not path_js.exists()
+
     link_tags = index_html.find_all("link")
     hrefs = [t.get("href") for t in link_tags]
     assert "_static/bootstrap.min.css" not in hrefs
 
     script_tags = index_html.find_all("script")
+    sources = [t.get("src") for t in script_tags]
+    assert "_static/bootstrap.min.js" not in sources
+
+    link_tags = unused_html.find_all("link")
+    hrefs = [t.get("href") for t in link_tags]
+    assert "_static/bootstrap.min.css" not in hrefs
+    script_tags = unused_html.find_all("script")
     sources = [t.get("src") for t in script_tags]
     assert "_static/bootstrap.min.js" not in sources


### PR DESCRIPTION
Making use of js/css static files conditional: only include them on
pages that use the extension.

Following API docs:
* https://www.sphinx-doc.org/en/master/development/theming.html#add-your-own-static-files-to-the-build-assets
* https://www.sphinx-doc.org/en/master/extdev/appapi.html#event-html-page-context

Dropping support for Sphinx 3.x due to using the above APIs (static
files seem to always be included).

No longer using _static_carousel, Sphinx was copying files to _static
anyway.