### PR TITLE
Moving linked image handling into Carousel.images

### DIFF
--- a/sphinx_carousel/carousel.py
+++ b/sphinx_carousel/carousel.py
@@ -29,7 +29,7 @@ class Carousel(SphinxDirective):
     }
 
     def images(self) -> List[Tuple[docutils_image, Optional[reference]]]:
-        """Return list of image nodes and other associated data used in the directive.
+        """Return list of image nodes along with other associated data.
 
         :return: Image node and parent reference node if :target: was specified.
         """

--- a/sphinx_carousel/carousel.py
+++ b/sphinx_carousel/carousel.py
@@ -5,9 +5,9 @@ https://github.com/Robpol86/sphinx-carousel
 https://pypi.org/project/sphinx-carousel
 """
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional, Tuple
 
-from docutils.nodes import document, Element, image as docutils_image
+from docutils.nodes import document, Element, image as docutils_image, reference
 from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
 from sphinx.util.docutils import SphinxDirective
@@ -28,12 +28,23 @@ class Carousel(SphinxDirective):
         "show_indicators": directives.flag,
     }
 
-    def images(self) -> List[docutils_image]:
-        """Return list of image nodes used in the directive."""
+    def images(self) -> List[Tuple[docutils_image, Optional[reference]]]:
+        """Return list of image nodes and other associated data used in the directive.
+
+        :return: Image node and parent reference node if :target: was specified.
+        """
         directive_content = Element()
         directive_content.document = self.state.document
         self.state.nested_parse(self.content, self.content_offset, directive_content)
-        return list(directive_content.traverse(docutils_image))
+
+        images = []
+        for image in directive_content.traverse(docutils_image):
+            # Handle linked images.
+            linked_image = image.parent if image.parent.hasattr("refuri") else None
+            # Done with image.
+            images.append((image, linked_image))
+
+        return images
 
     def config_eval_bool(self, name: str) -> bool:
         """Evaluate boolean parameters from directive options and Sphinx conf.py entries.
@@ -61,9 +72,9 @@ class Carousel(SphinxDirective):
 
         # Build carousel-inner div.
         items = []
-        for idx, image in enumerate(images):
+        for idx, (image, linked_image) in enumerate(images):
             image["classes"] += ["d-block", "w-100"]
-            items.append(nodes.CarouselItemNode(idx == 0, "", image.parent if image.parent.hasattr("refuri") else image))
+            items.append(nodes.CarouselItemNode(idx == 0, "", linked_image or image))
         inner_div = nodes.CarouselInnerNode("", *items)
         main_div.append(inner_div)
 

--- a/tests/unit_tests/test_linked_images.py
+++ b/tests/unit_tests/test_linked_images.py
@@ -22,9 +22,9 @@ def test(carousel: element.Tag):
 
     item = carousel_items[0]
     assert item["class"] == ["carousel-item", "active"]
-    a_href = item.next
+    a_href = item.find_next()
     assert a_href["href"] == "https://imgur.com/ppGH90J"
-    img = a_href.next
+    img = a_href.find_next()
     assert img["src"] == "https://i.imgur.com/ppGH90Jl.jpg"
     assert img["class"] == ["d-block", "w-100"]
     assert img["alt"] == img["src"]

--- a/tests/unit_tests/test_myst.py
+++ b/tests/unit_tests/test_myst.py
@@ -11,7 +11,7 @@ def test(carousel: element.Tag):
 
     item = carousel_items[0]
     assert item["class"] == ["carousel-item", "active"]
-    img = item.find_all("img")[0]
+    img = item.find_next()
     assert img["src"] == "https://i.imgur.com/fmJnevTl.jpg"
     assert img["class"] == ["d-block", "w-100"]
     assert img["alt"] == img["src"]

--- a/tests/unit_tests/test_slides_only.py
+++ b/tests/unit_tests/test_slides_only.py
@@ -23,14 +23,14 @@ def test(carousel: element.Tag):
 
     item = carousel_items[0]
     assert item["class"] == ["carousel-item", "active"]
-    img = item.find_all("img")[0]
+    img = item.find_next()
     assert img["src"] == "_images/local.jpg"
     assert img["class"] == ["d-block", "w-100"]
     assert img["alt"] == "Local Alt"
 
     item = carousel_items[1]
     assert item["class"] == ["carousel-item"]
-    img = item.find_all("img")[0]
+    img = item.find_next()
     assert img["src"] == "https://i.imgur.com/ppGH90Jl.jpg"
     assert img["class"] == ["d-block", "w-100"]
     assert img["alt"] == img["src"]


### PR DESCRIPTION
In tests using `.find_next()` instead of `.find_all("img")` since the
img tag is expected to be the first child element.

In tests using `.find_next()` instead of `.item` since the latter
doesn't guarantee the returned item to be an element, can be a newline
which we want to ignore.