### PR TITLE
Style changes.

### DIFF
--- a/sphinx_carousel/carousel.py
+++ b/sphinx_carousel/carousel.py
@@ -68,8 +68,10 @@ class Carousel(SphinxDirective):
     def run(self) -> List[Element]:
         """Main method."""
         main_div_id = f"carousel-{self.env.new_serialno('carousel')}"
-        data_ride = "" if "no_data_ride" in self.options else "carousel"
-        main_div = nodes.CarouselMainNode(main_div_id, data_ride)
+        main_div = nodes.CarouselMainNode(
+            main_div_id,
+            data_ride="" if "no_data_ride" in self.options else "carousel",
+        )
         images = self.images()
 
         # Build indicators.
@@ -100,7 +102,7 @@ def copy_static(app: Sphinx):
 
     :param app: Sphinx application object.
     """
-    if not app.config.carousel_add_bootstrap_css_js or app.builder.format != "html":
+    if not app.config.carousel_bootstrap_add_css_js or app.builder.format != "html":
         return
 
     static_in = Path(__file__).parent / "_static"
@@ -120,7 +122,7 @@ def include_static_on_demand(app: Sphinx, _: str, __: str, ___: dict, doctree: d
     :param ___: Unused.
     :param doctree: Tree of docutils nodes.
     """
-    if not app.config.carousel_add_bootstrap_css_js:
+    if not app.config.carousel_bootstrap_add_css_js:
         return
     if doctree and doctree.traverse(nodes.CarouselMainNode):
         app.add_css_file("bootstrap.css")
@@ -134,7 +136,7 @@ def setup(app: Sphinx) -> Dict[str, str]:
 
     :returns: Extension version.
     """
-    app.add_config_value("carousel_add_bootstrap_css_js", True, "html")
+    app.add_config_value("carousel_bootstrap_add_css_js", True, "html")
     app.add_config_value("carousel_show_controls", False, "html")
     app.add_config_value("carousel_show_indicators", False, "html")
     app.add_directive("carousel", Carousel)

--- a/sphinx_carousel/nodes.py
+++ b/sphinx_carousel/nodes.py
@@ -31,16 +31,15 @@ class BaseNode(nodes.Element, nodes.General):
 class CarouselMainNode(BaseNode):
     """Main div."""
 
-    def __init__(self, div_id: str, data_ride: str = "", rawsource: str = "", *children, **attributes):
+    def __init__(self, div_id: str, data_ride: str = "", *args, **kwargs):
         """Constructor.
 
         :param div_id: <div id="...">.
         :param data_ride: <div data-bs-ride="...">.
-        :param rawsource: Passed to parent class.
-        :param children: Passed to parent class.
-        :param attributes: Passed to parent class.
+        :param args: Passed to parent class.
+        :param kwargs: Passed to parent class.
         """
-        super().__init__(rawsource, *children, **attributes)
+        super().__init__(*args, **kwargs)
         self.div_id = div_id
         self.data_ride = data_ride
 
@@ -64,7 +63,7 @@ class CarouselInnerNode(BaseNode):
     @staticmethod
     def html_visit(writer: HTML5Translator, node: "CarouselInnerNode"):
         """Append opening tags to document body list."""
-        writer.body.append(writer.starttag(node, "div", "", **{"CLASS": "carousel-inner"}))
+        writer.body.append(writer.starttag(node, "div", "", CLASS="carousel-inner"))
 
     @staticmethod
     def html_depart(writer: HTML5Translator, _):
@@ -75,15 +74,14 @@ class CarouselInnerNode(BaseNode):
 class CarouselItemNode(BaseNode):
     """Div that contains an image."""
 
-    def __init__(self, active: bool, rawsource="", *children, **attributes):
+    def __init__(self, active: bool, *args, **kwargs):
         """Constructor.
 
         :param active: Append active class to div, needed for first image.
-        :param rawsource: Passed to parent class.
-        :param children: Passed to parent class.
-        :param attributes: Passed to parent class.
+        :param args: Passed to parent class.
+        :param kwargs: Passed to parent class.
         """
-        super().__init__(rawsource, *children, **attributes)
+        super().__init__(*args, **kwargs)
         self.active = active
 
     @staticmethod
@@ -92,7 +90,7 @@ class CarouselItemNode(BaseNode):
         classes = ["carousel-item"]
         if node.active:
             classes.append("active")
-        writer.body.append(writer.starttag(node, "div", "", **{"CLASS": " ".join(classes)}))
+        writer.body.append(writer.starttag(node, "div", "", CLASS=" ".join(classes)))
 
     @staticmethod
     def html_depart(writer: HTML5Translator, _):
@@ -103,16 +101,15 @@ class CarouselItemNode(BaseNode):
 class CarouselControlNode(BaseNode):
     """Previous/next buttons."""
 
-    def __init__(self, div_id: str, prev: bool = False, rawsource: str = "", *children, **attributes):
+    def __init__(self, div_id: str, prev: bool = False, *args, **kwargs):
         """Constructor.
 
         :param div_id: Corresponding CarouselMainNode div ID.
         :param prev: Previous button if True, else Next button.
-        :param rawsource: Passed to parent class.
-        :param children: Passed to parent class.
-        :param attributes: Passed to parent class.
+        :param args: Passed to parent class.
+        :param kwargs: Passed to parent class.
         """
-        super().__init__(rawsource, *children, **attributes)
+        super().__init__(*args, **kwargs)
         self.div_id = div_id
         self.prev = prev
 
@@ -132,7 +129,7 @@ class CarouselControlNode(BaseNode):
         }
         writer.body.append(writer.starttag(node, "span", "", **attributes_span))
         writer.body.append("</span>")
-        writer.body.append(writer.starttag(node, "span", "", **{"CLASS": "visually-hidden"}))
+        writer.body.append(writer.starttag(node, "span", "", CLASS="visually-hidden"))
         writer.body.append("Previous" if node.prev else "Next")
         writer.body.append("</span>")
 
@@ -145,23 +142,22 @@ class CarouselControlNode(BaseNode):
 class CarouselIndicatorsNode(BaseNode):
     """Indicators."""
 
-    def __init__(self, div_id: str, count: int, rawsource: str = "", *children, **attributes):
+    def __init__(self, div_id: str, count: int, *args, **kwargs):
         """Constructor.
 
         :param div_id: Corresponding CarouselMainNode div ID.
         :param count: Number of images.
-        :param rawsource: Passed to parent class.
-        :param children: Passed to parent class.
-        :param attributes: Passed to parent class.
+        :param args: Passed to parent class.
+        :param kwargs: Passed to parent class.
         """
-        super().__init__(rawsource, *children, **attributes)
+        super().__init__(*args, **kwargs)
         self.div_id = div_id
         self.count = count
 
     @staticmethod
     def html_visit(writer: HTML5Translator, node: "CarouselIndicatorsNode"):
         """Append opening tags to document body list."""
-        writer.body.append(writer.starttag(node, "div", "", **{"CLASS": "carousel-indicators"}))
+        writer.body.append(writer.starttag(node, "div", "", CLASS="carousel-indicators"))
         for i in range(node.count):
             attributes = {
                 "type": "button",
@@ -184,23 +180,23 @@ class CarouselIndicatorsNode(BaseNode):
 class CarouselCaptionNode(BaseNode):
     """Captions."""
 
-    def __init__(self, title: str = "", description: str = "", rawsource: str = "", *children, **attributes):
+    def __init__(self, title: str = "", description: str = "", *args, **kwargs):
         """Constructor.
 
         :param title: Caption heading.
         :param description: Caption paragraph.
-        :param rawsource: Passed to parent class.
-        :param children: Passed to parent class.
-        :param attributes: Passed to parent class.
+        :param args: Passed to parent class.
+        :param kwargs: Passed to parent class.
         """
-        super().__init__(rawsource, *children, **attributes)
+        super().__init__(*args, **kwargs)
         self.title = title
         self.description = description
 
     @staticmethod
     def html_visit(writer: HTML5Translator, node: "CarouselCaptionNode"):
         """Append opening tags to document body list."""
-        writer.body.append(writer.starttag(node, "div", "", **{"CLASS": "carousel-caption d-none d-md-block"}))
+        classes = ["carousel-caption", "d-none", "d-md-block"]
+        writer.body.append(writer.starttag(node, "div", "", CLASS=" ".join(classes)))
         if node.title:
             writer.body.append(writer.starttag(node, "h5", ""))
             writer.body.append(node.title)

--- a/tests/unit_tests/test_docs/test-static-off/conf.py
+++ b/tests/unit_tests/test_docs/test-static-off/conf.py
@@ -4,4 +4,4 @@ extensions = ["sphinx_carousel.carousel"]
 html_theme = "basic"
 master_doc = "index"
 nitpicky = True
-carousel_add_bootstrap_css_js = False
+carousel_bootstrap_add_css_js = False


### PR DESCRIPTION
Renaming `carousel_add_bootstrap_css_js` to
`carousel_bootstrap_add_css_js`.

Using `*args` and `**kwargs` in nodes.

Using `CLASS=` instead of `**{"CLASS":` when calling methods.