### PR TITLE
Avoid using `.emptytag()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,20 +42,3 @@ extensions = ["sphinx_carousel.carousel"]
 ```
 
 TODO https://github.com/executablebooks/sphinx-panels
-
-## TODOs
-
-* Use minified
-* Investigate style overrides
-* Investigate missing padding below carousel (maybe need to use nodes.container?)
-* WARNING on no images.
-* latex testing
-* Rename bootstrap.{css,js} to bootstrap-carousel.*
-* Test opengraph first image
-* Handle images with different aspect ratios
-* Caption text style/color with different images
-* Look at captions on mobile
-* Test links on mobile
-* Test very large caption.
-* Caption styling
-* Indicator/controls style: visible on dark and light images

--- a/sphinx_carousel/nodes.py
+++ b/sphinx_carousel/nodes.py
@@ -131,18 +131,22 @@ class CarouselControlNode(BaseNode):
             )
         )
 
+        # Nested icon.
         writer.body.append(
-            writer.emptytag(
+            writer.starttag(
                 node,
                 "span",
+                "",
                 CLASS=f"{prefix}carousel-control-{'prev' if node.prev else 'next'}-icon",
                 **{"aria-hidden": "true"},
             )
         )
+        writer.body.append("</span>\n")
 
-        writer.body.append(writer.starttag(node, "span", CLASS=f"{prefix}visually-hidden"))
+        # Nested hidden text for screen readers.
+        writer.body.append(writer.starttag(node, "span", "", CLASS=f"{prefix}visually-hidden"))
         writer.body.append("Previous" if node.prev else "Next")
-        writer.body.append("\n</span>\n")
+        writer.body.append("</span>\n")
 
     @staticmethod
     def html_depart(writer: HTML5Translator, _):
@@ -179,7 +183,8 @@ class CarouselIndicatorsNode(BaseNode):
             if i == 0:
                 attributes["CLASS"] = f"{prefix}active"
                 attributes["aria-current"] = "true"
-            writer.body.append(writer.emptytag(node, "button", type="button", **attributes))
+            writer.body.append(writer.starttag(node, "button", "", type="button", **attributes))
+            writer.body.append("</button>\n")
 
     @staticmethod
     def html_depart(writer: HTML5Translator, _):
@@ -209,9 +214,9 @@ class CarouselCaptionNode(BaseNode):
         classes = [f"{prefix}carousel-caption", f"{prefix}d-none", f"{prefix}d-md-block"]
         writer.body.append(writer.starttag(node, "div", CLASS=" ".join(classes)))
 
-        writer.body.append(writer.starttag(node, "h5"))
+        writer.body.append(writer.starttag(node, "h5", ""))
         writer.body.append(node.title)
-        writer.body.append("\n</h5>\n")
+        writer.body.append("</h5>\n")
 
         if node.description:
             writer.body.append(writer.starttag(node, "p"))


### PR DESCRIPTION
Span and button don't seem to be self-closing HTML5 tags. Reverting back
to `.starttag()`.

Nicer newlines in HTML output for style.

Moved TODOs to GitHub issues.