### PR TITLE
Adding feature to put captions below the image.

### DIFF
--- a/bootstrap/bootstrap.scss
+++ b/bootstrap/bootstrap.scss
@@ -13,7 +13,7 @@
 @import "../node_modules/bootstrap/scss/utilities";
 
 // Layout & components
-//@import "../node_modules/bootstrap/scss/root";
+@import "../node_modules/bootstrap/scss/root";
 //@import "../node_modules/bootstrap/scss/reboot";
 //@import "../node_modules/bootstrap/scss/type";
 //@import "../node_modules/bootstrap/scss/images";

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -8,6 +8,7 @@ Usage
     :data-bs-interval: false
     :show_controls:
     :show_indicators:
+    :show_captions_below:
 
     .. image:: https://i.imgur.com/fmJnevTl.jpg
         :target: https://i.imgur.com/fmJnevT.jpg

--- a/sphinx_carousel/_static/bootstrap.css
+++ b/sphinx_carousel/_static/bootstrap.css
@@ -4,6 +4,60 @@
  * Copyright 2011-2021 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
  */
+:root {
+  --bs-blue: #0d6efd;
+  --bs-indigo: #6610f2;
+  --bs-purple: #6f42c1;
+  --bs-pink: #d63384;
+  --bs-red: #dc3545;
+  --bs-orange: #fd7e14;
+  --bs-yellow: #ffc107;
+  --bs-green: #198754;
+  --bs-teal: #20c997;
+  --bs-cyan: #0dcaf0;
+  --bs-white: #fff;
+  --bs-gray: #6c757d;
+  --bs-gray-dark: #343a40;
+  --bs-gray-100: #f8f9fa;
+  --bs-gray-200: #e9ecef;
+  --bs-gray-300: #dee2e6;
+  --bs-gray-400: #ced4da;
+  --bs-gray-500: #adb5bd;
+  --bs-gray-600: #6c757d;
+  --bs-gray-700: #495057;
+  --bs-gray-800: #343a40;
+  --bs-gray-900: #212529;
+  --bs-primary: #0d6efd;
+  --bs-secondary: #6c757d;
+  --bs-success: #198754;
+  --bs-info: #0dcaf0;
+  --bs-warning: #ffc107;
+  --bs-danger: #dc3545;
+  --bs-light: #f8f9fa;
+  --bs-dark: #212529;
+  --bs-primary-rgb: 13, 110, 253;
+  --bs-secondary-rgb: 108, 117, 125;
+  --bs-success-rgb: 25, 135, 84;
+  --bs-info-rgb: 13, 202, 240;
+  --bs-warning-rgb: 255, 193, 7;
+  --bs-danger-rgb: 220, 53, 69;
+  --bs-light-rgb: 248, 249, 250;
+  --bs-dark-rgb: 33, 37, 41;
+  --bs-white-rgb: 255, 255, 255;
+  --bs-black-rgb: 0, 0, 0;
+  --bs-body-color-rgb: 33, 37, 41;
+  --bs-body-bg-rgb: 255, 255, 255;
+  --bs-font-sans-serif: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --bs-font-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --bs-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0));
+  --bs-body-font-family: var(--bs-font-sans-serif);
+  --bs-body-font-size: 1rem;
+  --bs-body-font-weight: 400;
+  --bs-body-line-height: 1.5;
+  --bs-body-color: #212529;
+  --bs-body-bg: #fff;
+}
+
 .scbs-carousel {
   position: relative;
 }

--- a/sphinx_carousel/carousel.py
+++ b/sphinx_carousel/carousel.py
@@ -21,16 +21,22 @@ class Carousel(SphinxDirective):
 
     has_content = True
     option_spec = {
+        # Div data attributes.
         "data-bs-interval": directives.unchanged,
         "data-bs-keyboard": directives.unchanged,
         "data-bs-pause": directives.unchanged,
         "data-bs-ride": directives.unchanged,
         "data-bs-wrap": directives.unchanged,
         "data-bs-touch": directives.unchanged,
+        # Controls.
         "no_controls": directives.flag,
         "show_controls": directives.flag,
+        # Indicators.
         "no_indicators": directives.flag,
         "show_indicators": directives.flag,
+        # Captions.
+        "no_captions_below": directives.flag,
+        "show_captions_below": directives.flag,
     }
 
     def images(self) -> List[Tuple[docutils_image, Optional[reference], Optional[str], Optional[str]]]:
@@ -85,12 +91,13 @@ class Carousel(SphinxDirective):
 
         # Build carousel-inner div.
         prefix = self.config["carousel_bootstrap_prefix"]
+        captions_below = self.config_read_flag("captions_below")
         items = []
         for idx, (image, linked_image, title, description) in enumerate(images):
             image["classes"] += [f"{prefix}d-block", f"{prefix}w-100"]
             child_nodes = [linked_image or image]
             if title or description:
-                child_nodes.append(nodes.CarouselCaptionNode(title, description))
+                child_nodes.append(nodes.CarouselCaptionNode(title, description, below=captions_below))
             items.append(nodes.CarouselItemNode(idx == 0, "", *child_nodes))
         inner_div = nodes.CarouselInnerNode("", *items)
         main_div.append(inner_div)
@@ -144,6 +151,7 @@ def setup(app: Sphinx) -> Dict[str, str]:
     """
     app.add_config_value("carousel_bootstrap_add_css_js", True, "html")
     app.add_config_value("carousel_bootstrap_prefix", "scbs-", "html")
+    app.add_config_value("carousel_show_captions_below", False, "html")
     app.add_config_value("carousel_show_controls", False, "html")
     app.add_config_value("carousel_show_indicators", False, "html")
     app.add_directive("carousel", Carousel)

--- a/tests/unit_tests/test_captions_below.py
+++ b/tests/unit_tests/test_captions_below.py
@@ -1,0 +1,37 @@
+"""Tests."""
+from typing import List
+
+import pytest
+from bs4 import element
+
+
+@pytest.mark.sphinx("html", testroot="captions-below")
+def test_toggle(carousels: List[element.Tag]):
+    """Test."""
+    caption_div = carousels[0].find_all("div", ["scbs-carousel-caption"])[0]
+    assert caption_div["class"] == ["scbs-carousel-caption", "scbs-bg-dark", "scbs-d-sm-block"]
+    assert caption_div["style"].find("position: relative") >= 0
+
+    caption_div = carousels[1].find_all("div", ["scbs-carousel-caption"])[0]
+    assert caption_div["class"] == ["scbs-carousel-caption", "scbs-d-none", "scbs-d-md-block"]
+    assert caption_div.has_attr("style") is False
+
+    caption_div = carousels[2].find_all("div", ["scbs-carousel-caption"])[0]
+    assert caption_div["class"] == ["scbs-carousel-caption", "scbs-d-none", "scbs-d-md-block"]
+    assert caption_div.has_attr("style") is False
+
+
+@pytest.mark.sphinx("html", testroot="captions-below-conf")
+def test_toggle_conf(carousels: List[element.Tag]):
+    """Test."""
+    caption_div = carousels[0].find_all("div", ["scbs-carousel-caption"])[0]
+    assert caption_div["class"] == ["scbs-carousel-caption", "scbs-bg-dark", "scbs-d-sm-block"]
+    assert caption_div["style"].find("position: relative") >= 0
+
+    caption_div = carousels[1].find_all("div", ["scbs-carousel-caption"])[0]
+    assert caption_div["class"] == ["scbs-carousel-caption", "scbs-d-none", "scbs-d-md-block"]
+    assert caption_div.has_attr("style") is False
+
+    caption_div = carousels[2].find_all("div", ["scbs-carousel-caption"])[0]
+    assert caption_div["class"] == ["scbs-carousel-caption", "scbs-bg-dark", "scbs-d-sm-block"]
+    assert caption_div["style"].find("position: relative") >= 0

--- a/tests/unit_tests/test_docs/test-captions-below-conf/conf.py
+++ b/tests/unit_tests/test_docs/test-captions-below-conf/conf.py
@@ -1,0 +1,7 @@
+"""Sphinx test configuration."""
+exclude_patterns = ["_build"]
+extensions = ["sphinx_carousel.carousel"]
+html_theme = "basic"
+master_doc = "index"
+nitpicky = True
+carousel_show_captions_below = True

--- a/tests/unit_tests/test_docs/test-captions-below-conf/index.rst
+++ b/tests/unit_tests/test_docs/test-captions-below-conf/index.rst
@@ -1,0 +1,21 @@
+.. carousel::
+    :show_captions_below:
+
+    .. figure:: https://i.imgur.com/fmJnevTl.jpg
+
+        Example Title
+
+
+.. carousel::
+    :no_captions_below:
+
+    .. figure:: https://i.imgur.com/fmJnevTl.jpg
+
+        Example Title
+
+
+.. carousel::
+
+    .. figure:: https://i.imgur.com/fmJnevTl.jpg
+
+        Example Title

--- a/tests/unit_tests/test_docs/test-captions-below/conf.py
+++ b/tests/unit_tests/test_docs/test-captions-below/conf.py
@@ -1,0 +1,6 @@
+"""Sphinx test configuration."""
+exclude_patterns = ["_build"]
+extensions = ["sphinx_carousel.carousel"]
+html_theme = "basic"
+master_doc = "index"
+nitpicky = True

--- a/tests/unit_tests/test_docs/test-captions-below/index.rst
+++ b/tests/unit_tests/test_docs/test-captions-below/index.rst
@@ -1,0 +1,21 @@
+.. carousel::
+    :show_captions_below:
+
+    .. figure:: https://i.imgur.com/fmJnevTl.jpg
+
+        Example Title
+
+
+.. carousel::
+    :no_captions_below:
+
+    .. figure:: https://i.imgur.com/fmJnevTl.jpg
+
+        Example Title
+
+
+.. carousel::
+
+    .. figure:: https://i.imgur.com/fmJnevTl.jpg
+
+        Example Title


### PR DESCRIPTION
Below instead of overlaying captions makes more sense when captions are
large. Also overlayed captions are hidden on mobile, but visible when
below.

Enabling root Bootstrap component. Only adds `--bs-*` css variables.

Moving some strings into node class variables so that they can be
modified in users' conf.py file.