### PR TITLE
New feature: buttons_on_top

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -9,6 +9,7 @@ Usage
     :show_controls:
     :show_indicators:
     :show_captions_below:
+    :show_buttons_on_top:
 
     .. image:: https://i.imgur.com/fmJnevTl.jpg
         :target: https://i.imgur.com/fmJnevT.jpg

--- a/sphinx_carousel/_static/carousel-custom.css
+++ b/sphinx_carousel/_static/carousel-custom.css
@@ -1,3 +1,11 @@
+.scc-top-c {
+    align-items: start;
+}
+
+.scc-top-i {
+    bottom: unset;
+}
+
 .scc-below-c {
     position: relative;
     left: 0;

--- a/sphinx_carousel/carousel.py
+++ b/sphinx_carousel/carousel.py
@@ -35,10 +35,11 @@ class Carousel(SphinxDirective):
         "show_fade": directives.flag,
         "no_dark": directives.flag,
         "show_dark": directives.flag,
-        # Controls.
+        # Controls/indicators.
+        "no_buttons_on_top": directives.flag,
+        "show_buttons_on_top": directives.flag,
         "no_controls": directives.flag,
         "show_controls": directives.flag,
-        # Indicators.
         "no_indicators": directives.flag,
         "show_indicators": directives.flag,
         # Captions.
@@ -113,18 +114,19 @@ class Carousel(SphinxDirective):
             dark=dark_variant,
         )
         images = self.images()
+        buttons_on_top = self.config_read_flag("buttons_on_top")
 
         # Build indicators.
         if self.config_read_flag("indicators"):
-            main_div.append(nodes.CarouselIndicatorsNode(main_div_id, len(images)))
+            main_div.append(nodes.CarouselIndicatorsNode(main_div_id, len(images), top=buttons_on_top))
 
         # Build carousel-inner div.
         main_div.append(self.create_inner_node(images, dark_variant))
 
         # Build control buttons.
         if self.config_read_flag("controls"):
-            main_div.append(nodes.CarouselControlNode(main_div_id, prev=True))
-            main_div.append(nodes.CarouselControlNode(main_div_id))
+            main_div.append(nodes.CarouselControlNode(main_div_id, top=buttons_on_top, prev=True))
+            main_div.append(nodes.CarouselControlNode(main_div_id, top=buttons_on_top))
 
         return [main_div]
 
@@ -176,6 +178,7 @@ def setup(app: Sphinx) -> Dict[str, str]:
     """
     app.add_config_value("carousel_bootstrap_add_css_js", True, "html")
     app.add_config_value("carousel_bootstrap_prefix", "scbs-", "html")
+    app.add_config_value("carousel_show_buttons_on_top", False, "html")
     app.add_config_value("carousel_show_captions_below", False, "html")
     app.add_config_value("carousel_show_controls", False, "html")
     app.add_config_value("carousel_show_fade", False, "html")

--- a/sphinx_carousel/nodes.py
+++ b/sphinx_carousel/nodes.py
@@ -114,28 +114,33 @@ class CarouselControlNode(BaseNode):
     NEXT_ICON = "carousel-control-next"
     PREV_ICON = "carousel-control-prev"
 
-    def __init__(self, div_id: str, prev: bool = False, *args, **kwargs):
+    def __init__(self, div_id: str, prev: bool = False, top: bool = False, *args, **kwargs):
         """Constructor.
 
         :param div_id: Corresponding CarouselMainNode div ID.
         :param prev: Previous button if True, else Next button.
+        :param top: Display controls at the top of the image instead of the middle.
         :param args: Passed to parent class.
         :param kwargs: Passed to parent class.
         """
         super().__init__(*args, **kwargs)
         self.div_id = div_id
         self.prev = prev
+        self.top = top
 
     @staticmethod
     def html_visit(writer: HTML5Translator, node: "CarouselControlNode"):
         """Append opening tags to document body list."""
         prefix = writer.config["carousel_bootstrap_prefix"]
 
+        classes = [f"{prefix}{node.PREV_ICON if node.prev else node.NEXT_ICON}"]
+        if node.top:
+            classes.extend([f"{prefix}my-4", "scc-top-c"])
         writer.body.append(
             writer.starttag(
                 node,
                 "button",
-                CLASS=f"{prefix}{node.PREV_ICON if node.prev else node.NEXT_ICON}",
+                CLASS=" ".join(classes),
                 type="button",
                 **{"data-bs-target": f"#{node.div_id}", "data-bs-slide": "prev" if node.prev else "next"},
             )
@@ -167,23 +172,28 @@ class CarouselControlNode(BaseNode):
 class CarouselIndicatorsNode(BaseNode):
     """Indicators."""
 
-    def __init__(self, div_id: str, count: int, *args, **kwargs):
+    def __init__(self, div_id: str, count: int, top: bool = False, *args, **kwargs):
         """Constructor.
 
         :param div_id: Corresponding CarouselMainNode div ID.
         :param count: Number of images.
+        :param top: Display indicators at the top of the image instead of the middle.
         :param args: Passed to parent class.
         :param kwargs: Passed to parent class.
         """
         super().__init__(*args, **kwargs)
         self.div_id = div_id
         self.count = count
+        self.top = top
 
     @staticmethod
     def html_visit(writer: HTML5Translator, node: "CarouselIndicatorsNode"):
         """Append opening tags to document body list."""
         prefix = writer.config["carousel_bootstrap_prefix"]
-        writer.body.append(writer.starttag(node, "div", CLASS=f"{prefix}carousel-indicators"))
+        classes = [f"{prefix}carousel-indicators"]
+        if node.top:
+            classes.extend([f"{prefix}my-4", "scc-top-i"])
+        writer.body.append(writer.starttag(node, "div", CLASS=" ".join(classes)))
 
         # Add indicator buttons.
         for i in range(node.count):

--- a/tests/unit_tests/test_buttons_on_top.py
+++ b/tests/unit_tests/test_buttons_on_top.py
@@ -1,0 +1,44 @@
+"""Tests."""
+from typing import List
+
+import pytest
+from bs4 import element
+
+ROOTS = ("buttons-on-top/default", "buttons-on-top/sphinx-conf")
+
+
+@pytest.mark.parametrize("testroot", [pytest.param(r, marks=pytest.mark.sphinx("html", testroot=r)) for r in ROOTS])
+def test(carousels: List[element.Tag], testroot: str):
+    """Test."""
+    indicators = carousels[0].find_all("div", ["scbs-carousel-indicators"])[0]
+    control_prev = carousels[0].find_all("button", ["scbs-carousel-control-prev"])[0]
+    control_next = carousels[0].find_all("button", ["scbs-carousel-control-next"])[0]
+    assert indicators["class"] == ["scbs-carousel-indicators", "scbs-my-4", "scc-top-i"]
+    assert control_prev["class"] == ["scbs-carousel-control-prev", "scbs-my-4", "scc-top-c"]
+    assert control_next["class"] == ["scbs-carousel-control-next", "scbs-my-4", "scc-top-c"]
+
+    indicators = carousels[1].find_all("div", ["scbs-carousel-indicators"])[0]
+    control_prev = carousels[1].find_all("button", ["scbs-carousel-control-prev"])[0]
+    control_next = carousels[1].find_all("button", ["scbs-carousel-control-next"])[0]
+    assert indicators["class"] == ["scbs-carousel-indicators"]
+    assert control_prev["class"] == ["scbs-carousel-control-prev"]
+    assert control_next["class"] == ["scbs-carousel-control-next"]
+
+    indicators = carousels[2].find_all("div", ["scbs-carousel-indicators"])[0]
+    control_prev = carousels[2].find_all("button", ["scbs-carousel-control-prev"])[0]
+    control_next = carousels[2].find_all("button", ["scbs-carousel-control-next"])[0]
+    if testroot.endswith("conf"):
+        assert indicators["class"] == ["scbs-carousel-indicators", "scbs-my-4", "scc-top-i"]
+        assert control_prev["class"] == ["scbs-carousel-control-prev", "scbs-my-4", "scc-top-c"]
+        assert control_next["class"] == ["scbs-carousel-control-next", "scbs-my-4", "scc-top-c"]
+    else:
+        assert indicators["class"] == ["scbs-carousel-indicators"]
+        assert control_prev["class"] == ["scbs-carousel-control-prev"]
+        assert control_next["class"] == ["scbs-carousel-control-next"]
+
+    indicators = carousels[3].find_all("div", ["scbs-carousel-indicators"])
+    control_prev = carousels[3].find_all("button", ["scbs-carousel-control-prev"])
+    control_next = carousels[3].find_all("button", ["scbs-carousel-control-next"])
+    assert not indicators
+    assert not control_prev
+    assert not control_next

--- a/tests/unit_tests/test_docs/test-buttons-on-top/default/conf.py
+++ b/tests/unit_tests/test_docs/test-buttons-on-top/default/conf.py
@@ -1,0 +1,6 @@
+"""Sphinx test configuration."""
+exclude_patterns = ["_build"]
+extensions = ["sphinx_carousel.carousel"]
+html_theme = "basic"
+master_doc = "index"
+nitpicky = True

--- a/tests/unit_tests/test_docs/test-buttons-on-top/default/index.rst
+++ b/tests/unit_tests/test_docs/test-buttons-on-top/default/index.rst
@@ -1,0 +1,34 @@
+.. carousel::
+    :show_controls:
+    :show_indicators:
+    :show_buttons_on_top:
+
+    .. figure:: https://i.imgur.com/fmJnevTl.jpg
+
+        Example Title
+
+
+.. carousel::
+    :show_controls:
+    :show_indicators:
+    :no_buttons_on_top:
+
+    .. figure:: https://i.imgur.com/fmJnevTl.jpg
+
+        Example Title
+
+
+.. carousel::
+    :show_controls:
+    :show_indicators:
+
+    .. figure:: https://i.imgur.com/fmJnevTl.jpg
+
+        Example Title
+
+
+.. carousel::
+
+    .. figure:: https://i.imgur.com/fmJnevTl.jpg
+
+        Example Title

--- a/tests/unit_tests/test_docs/test-buttons-on-top/sphinx-conf/conf.py
+++ b/tests/unit_tests/test_docs/test-buttons-on-top/sphinx-conf/conf.py
@@ -1,0 +1,7 @@
+"""Sphinx test configuration."""
+exclude_patterns = ["_build"]
+extensions = ["sphinx_carousel.carousel"]
+html_theme = "basic"
+master_doc = "index"
+nitpicky = True
+carousel_show_buttons_on_top = True

--- a/tests/unit_tests/test_docs/test-buttons-on-top/sphinx-conf/index.rst
+++ b/tests/unit_tests/test_docs/test-buttons-on-top/sphinx-conf/index.rst
@@ -1,0 +1,34 @@
+.. carousel::
+    :show_controls:
+    :show_indicators:
+    :show_buttons_on_top:
+
+    .. figure:: https://i.imgur.com/fmJnevTl.jpg
+
+        Example Title
+
+
+.. carousel::
+    :show_controls:
+    :show_indicators:
+    :no_buttons_on_top:
+
+    .. figure:: https://i.imgur.com/fmJnevTl.jpg
+
+        Example Title
+
+
+.. carousel::
+    :show_controls:
+    :show_indicators:
+
+    .. figure:: https://i.imgur.com/fmJnevTl.jpg
+
+        Example Title
+
+
+.. carousel::
+
+    .. figure:: https://i.imgur.com/fmJnevTl.jpg
+
+        Example Title


### PR DESCRIPTION
This solves a UX problem where a carousel containing images with
different aspect ratios or different caption lengths cause the prev/next
controls to shift when sliding to the next/prev image. This happens
because the controls are set to be in the middle of the entire carousel,
so taller images and longer captions extend the height of the carousel
and affect the button placements.

This option pins the controls to the top of the carousel so they no
longer move when the above situation occurs. The indicators are also
pinned to the top since they too move around as they're pinned to the
bottom of the carousel by default.