### PR TITLE
Warn on carousel without images/figures.

### DIFF
--- a/sphinx_carousel/carousel.py
+++ b/sphinx_carousel/carousel.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional, Tuple
 from docutils.nodes import caption, document, Element, image as docutils_image, legend, reference
 from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
+from sphinx.util import logging as sphinx_logging
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.fileutil import copy_asset_file
 
@@ -107,6 +108,12 @@ class Carousel(SphinxDirective):
 
     def run(self) -> List[Element]:
         """Main method."""
+        images = self.images()
+        if not images:
+            log = sphinx_logging.getLogger(__name__)
+            log.warning("No images specified in carousel.", location=(self.env.docname, self.lineno))
+            return []
+
         main_div_id = f"carousel-{self.env.new_serialno('carousel')}"
         dark_variant = self.config_read_flag("dark")
         main_div = nodes.CarouselMainNode(
@@ -115,7 +122,6 @@ class Carousel(SphinxDirective):
             fade=self.config_read_flag("fade"),
             dark=dark_variant,
         )
-        images = self.images()
         buttons_on_top = self.config_read_flag("buttons_on_top")
         shadows = self.config_read_flag("shadows")
 

--- a/tests/unit_tests/test_docs/test-no-image-warn/conf.py
+++ b/tests/unit_tests/test_docs/test-no-image-warn/conf.py
@@ -1,0 +1,6 @@
+"""Sphinx test configuration."""
+exclude_patterns = ["_build"]
+extensions = ["sphinx_carousel.carousel"]
+html_theme = "basic"
+master_doc = "index"
+nitpicky = True

--- a/tests/unit_tests/test_docs/test-no-image-warn/index.rst
+++ b/tests/unit_tests/test_docs/test-no-image-warn/index.rst
@@ -1,0 +1,3 @@
+Test
+
+.. carousel::

--- a/tests/unit_tests/test_no_image_warn.py
+++ b/tests/unit_tests/test_no_image_warn.py
@@ -1,0 +1,14 @@
+"""Tests."""
+from io import StringIO
+from typing import List
+
+import pytest
+from bs4 import element
+
+
+@pytest.mark.sphinx("html", testroot="no-image-warn")
+def test(carousels: List[element.Tag], warning: StringIO):
+    """Test."""
+    assert not carousels
+    warnings = warning.getvalue().strip()
+    assert "index.rst:3: WARNING: No images specified in carousel." in warnings


### PR DESCRIPTION
Emit a warning when a carousel directive is used but lacks any images.
Then return an empty list so generated Sphinx docs will just ignore the
directive.

Fixes https://github.com/Robpol86/sphinx-carousel/issues/30