### PR TITLE
Fix exception when building with LaTeX builder.

### DIFF
--- a/sphinx_carousel/carousel.py
+++ b/sphinx_carousel/carousel.py
@@ -100,8 +100,8 @@ class Carousel(SphinxDirective):
             image["classes"] += [f"{prefix}d-block", f"{prefix}w-100"]
             child_nodes = [linked_image or image]
             if title or description:
-                child_nodes.append(nodes.CarouselCaptionNode(title, description, below=captions_below))
-            items.append(nodes.CarouselItemNode(idx == 0, "", *child_nodes))
+                child_nodes.append(nodes.CarouselCaptionNode(title=title, description=description, below=captions_below))
+            items.append(nodes.CarouselItemNode("", *child_nodes, active=idx == 0))
 
         return nodes.CarouselInnerNode("", *items)
 
@@ -125,7 +125,7 @@ class Carousel(SphinxDirective):
 
         # Build indicators.
         if self.config_read_flag("indicators"):
-            main_div.append(nodes.CarouselIndicatorsNode(len(images), top=buttons_on_top, shadow=shadows))
+            main_div.append(nodes.CarouselIndicatorsNode(count=len(images), top=buttons_on_top, shadow=shadows))
 
         # Build carousel-inner div.
         main_div.append(self.create_inner_node(images))

--- a/sphinx_carousel/nodes.py
+++ b/sphinx_carousel/nodes.py
@@ -26,23 +26,37 @@ class BaseNode(nodes.Element, nodes.General):
     @classmethod
     def add_node(cls, app: Sphinx):
         """Convenience method that adds the subclass node to the Sphinx app.."""
-        app.add_node(cls, html=(cls.html_visit, cls.html_depart))
+        app.add_node(
+            cls,
+            html=(cls.html_visit, cls.html_depart),
+            latex=(lambda *_: None, lambda *_: None),  # TODO https://github.com/Robpol86/sphinx-carousel/issues/50
+            man=(lambda *_: None, lambda *_: None),  # TODO https://github.com/Robpol86/sphinx-carousel/issues/51
+            texinfo=(lambda *_: None, lambda *_: None),  # TODO https://github.com/Robpol86/sphinx-carousel/issues/51
+            text=(lambda *_: None, lambda *_: None),  # TODO https://github.com/Robpol86/sphinx-carousel/issues/51
+        )
 
 
 class CarouselMainNode(BaseNode):
     """Main div."""
 
     def __init__(
-        self, div_id: str, prefix: str, attributes: Dict[str, str], fade: bool = False, dark: bool = False, *args, **kwargs
+        self,
+        *args,
+        div_id: str = "",
+        prefix: str = "",
+        attributes: Dict[str, str] = None,
+        fade: bool = False,
+        dark: bool = False,
+        **kwargs,
     ):
         """Constructor.
 
+        :param args: Passed to parent class.
         :param div_id: <div id="...">.
         :param prefix: Bootstrap class' prefix.
         :param attributes: Div attributes (e.g. {"data-bs-ride": "carousel", ...}.
         :param fade: Fade between images instead of using a slide transition.
         :param dark: Carousel dark variant.
-        :param args: Passed to parent class.
         :param kwargs: Passed to parent class.
         """
         super().__init__(*args, **kwargs)
@@ -99,11 +113,11 @@ class CarouselInnerNode(SubNode):
 class CarouselItemNode(SubNode):
     """Div that contains an image."""
 
-    def __init__(self, active: bool, *args, **kwargs):
+    def __init__(self, *args, active: bool = False, **kwargs):
         """Constructor.
 
-        :param active: Append active class to div, needed for first image.
         :param args: Passed to parent class.
+        :param active: Append active class to div, needed for first image.
         :param kwargs: Passed to parent class.
         """
         super().__init__(*args, **kwargs)
@@ -134,13 +148,13 @@ class CarouselControlNode(SubNode):
     NEXT_ICON = "carousel-control-next"
     PREV_ICON = "carousel-control-prev"
 
-    def __init__(self, prev: bool = False, top: bool = False, shadow: bool = False, *args, **kwargs):
+    def __init__(self, *args, prev: bool = False, top: bool = False, shadow: bool = False, **kwargs):
         """Constructor.
 
+        :param args: Passed to parent class.
         :param prev: Previous button if True, else Next button.
         :param top: Display controls at the top of the image instead of the middle.
         :param shadow: Show a shadow around the icons for better visibility when an image is a similar color.
-        :param args: Passed to parent class.
         :param kwargs: Passed to parent class.
         """
         super().__init__(*args, **kwargs)
@@ -192,13 +206,13 @@ class CarouselControlNode(SubNode):
 class CarouselIndicatorsNode(SubNode):
     """Indicators."""
 
-    def __init__(self, count: int, top: bool = False, shadow: bool = False, *args, **kwargs):
+    def __init__(self, *args, count: int = 0, top: bool = False, shadow: bool = False, **kwargs):
         """Constructor.
 
+        :param args: Passed to parent class.
         :param count: Number of images.
         :param top: Display indicators at the top of the image instead of the middle.
         :param shadow: Show a shadow around the icons for better visibility when an image is a similar color.
-        :param args: Passed to parent class.
         :param kwargs: Passed to parent class.
         """
         super().__init__(*args, **kwargs)
@@ -244,13 +258,13 @@ class CarouselCaptionNode(SubNode):
     BELOW_BG_DARK = "bg-dark"
     BELOW_BG_LIGHT = "bg-light"
 
-    def __init__(self, title: str = "", description: str = "", below: bool = False, *args, **kwargs):
+    def __init__(self, *args, title: str = "", description: str = "", below: bool = False, **kwargs):
         """Constructor.
 
+        :param args: Passed to parent class.
         :param title: Caption heading.
         :param description: Caption paragraph.
         :param below: Display caption below image instead of overlayed on top.
-        :param args: Passed to parent class.
         :param kwargs: Passed to parent class.
         """
         super().__init__(*args, **kwargs)

--- a/tests/unit_tests/test_static.py
+++ b/tests/unit_tests/test_static.py
@@ -24,6 +24,18 @@ def test_copied(sphinx_app: SphinxTestApp, testroot: str):
         assert not path_bs_js.is_file()
 
 
+@pytest.mark.parametrize("_", [pytest.param(r, marks=pytest.mark.sphinx("latex", testroot=r)) for r in ROOTS])
+def test_copied_latex(sphinx_app: SphinxTestApp, _):
+    """Test."""
+    path_custom_css = Path(sphinx_app.outdir) / "_static" / "carousel-custom.css"
+    assert not path_custom_css.is_file()
+
+    path_bs_css = Path(sphinx_app.outdir) / "_static" / "bootstrap-carousel.css"
+    path_bs_js = Path(sphinx_app.outdir) / "_static" / "bootstrap-carousel.js"
+    assert not path_bs_css.is_file()
+    assert not path_bs_js.is_file()
+
+
 @pytest.mark.parametrize("testroot", [pytest.param(r, marks=pytest.mark.sphinx("html", testroot=r)) for r in ROOTS])
 def test_index(index_html: BeautifulSoup, testroot: str):
     """Test."""


### PR DESCRIPTION
LaTeX not yet supported but no longer breaks when using the Sphinx
builder.

Passing all custom node arguments as kwargs and moving `*args` to the
front of the `__init__()` signature.

Fixes https://github.com/Robpol86/sphinx-carousel/issues/32