### PR TITLE
Implementing hacky Sphinx multi-theme support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,13 @@ jobs:
         os: [ubuntu-latest]
         python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         sphinx: [""]
+        multi_theme: ["true"]
         include:
           - os: macos-latest
             python: "3.10"
           - os: windows-latest
             python: "3.10"
+            multi_theme: "false"
           - os: ubuntu-latest
             python: "3.9"
             sphinx: "4.0.3"
@@ -30,7 +32,7 @@ jobs:
       - {name: Run lints, run: make lint}
       - {name: Run tests, run: make test, env: {PY_COLORS: 1}}
       - {name: Run integration tests, run: make it}
-      - {name: Build docs, run: make docs}
+      - {name: Build docs, run: make docs, env: {SPHINX_MULTI_THEME: "${{matrix.multi_theme}}"}}
       - {name: Build package, run: make build}
       - name: Upload coverage
         uses: codecov/codecov-action@v2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,6 +2,8 @@
 # pylint: disable=invalid-name
 import time
 
+from sphinx_carousel.unrelated import MultiTheme
+
 
 # General configuration.
 author = "Robpol86"
@@ -22,7 +24,13 @@ pygments_style = "vs"
 
 # Options for HTML output.
 html_copy_source = False
-html_theme = "sphinx_rtd_theme"
+html_theme = MultiTheme.select_theme(
+    [
+        "sphinx_rtd_theme",  # https://sphinx-themes.org/sample-sites/sphinx-rtd-theme/
+        "alabaster",  # https://sphinx-themes.org/sample-sites/default-alabaster/
+        "classic",  # https://sphinx-themes.org/sample-sites/default-classic/
+    ]
+)
 
 
 # https://sphinxext-opengraph.readthedocs.io/en/latest/#options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ line-length = 125
 target-version = ["py36", "py37", "py38", "py39", "py310"]
 [tool.coverage.report]
 exclude_lines = [
+    "#\\s*pragma: no cover",
     "^\\s*from",
     "^\\s*import",
     "^\\s*raise AssertionError",

--- a/sphinx_carousel/unrelated.py
+++ b/sphinx_carousel/unrelated.py
@@ -1,0 +1,110 @@
+"""Code unrelated and out of scope of the main project.
+
+Code here is placed temporarily until I have enough time to move it to its own separate project.
+"""
+import inspect
+import os
+from typing import List, Optional
+
+from sphinx.application import Sphinx
+from sphinx.errors import SphinxError
+from sphinx.util import ensuredir, logging
+
+
+class MultiTheme:  # noqa
+    """Build multiple themes."""
+
+    DIRECTORY_PREFIX = "theme_"
+
+    @staticmethod
+    def get_sphinx_app() -> Optional[Sphinx]:  # pragma: no cover
+        """Inspect call stack and return the Sphinx app instance if found."""
+        for frame in inspect.stack():
+            app = frame[0].f_locals.get("self", None)
+            if app and isinstance(app, Sphinx):
+                return app
+        return None
+
+    @classmethod
+    def modify_sphinx_app(cls, app: Sphinx, theme: str):  # pragma: no cover
+        """Make changes to the Sphinx app.
+
+        :param app: Sphinx app instance to modify.
+        :param theme: Current theme being used.
+        """
+        log = logging.getLogger(__file__)
+        subdir = f"{cls.DIRECTORY_PREFIX}{theme}"
+        old_outdir = app.outdir
+        old_doctreedir = app.doctreedir
+
+        new_outdir = os.path.join(old_outdir, subdir)
+        ensuredir(new_outdir)
+        log.info(">>> Changing outdir from %s to %s", old_outdir, new_outdir)
+        app.outdir = new_outdir
+
+        new_doctreedir = old_doctreedir.replace(old_outdir, new_outdir)
+        if new_doctreedir == old_doctreedir:
+            new_doctreedir = os.path.join(old_doctreedir, subdir)
+        log.info(">>> Changing doctreedir from %s to %s", old_doctreedir, new_doctreedir)
+        app.doctreedir = new_doctreedir
+
+    @staticmethod
+    def fork() -> bool:  # pragma: no cover
+        """Fork Python process and wait for the child process to finish.
+
+        :return: True if this is the child process, False if this is still the original/parent process.
+        """
+        pid = os.fork()  # noqa  # pylint: disable=no-member
+        if pid < 0:
+            raise SphinxError(f"Fork failed ({pid})")
+        if pid == 0:  # This is the child process.
+            return True
+
+        # This is the parent (original) process. Wait (block) for child to finish.
+        exit_status = os.waitpid(pid, 0)[1] // 256  # https://code-maven.com/python-fork-and-wait
+        if exit_status != 0:
+            raise SphinxError(f"Child process {pid} failed with status {exit_status}")
+
+        return False
+
+    @classmethod
+    def select_theme(cls, themes: List[str]) -> str:
+        """Build copies of all docs using multiple themes in separate subdirectories.
+
+        The first theme in the list is the default/root theme. All other themes will be built in a forked process into a
+        prefixed subdirectory. At the end of the function the root theme is returned to the main process and Sphinx will
+        continue building it in the original output directory.
+
+        :param themes: List of theme names as expected by the `html_theme` Sphinx config value.
+
+        :return: The theme to use for the current build.
+        """
+        log = logging.getLogger(__file__)
+
+        # Skip conditionals.
+        if len(themes) < 2:
+            return themes[0]
+        if os.environ.get("SPHINX_MULTI_THEME") == "false":
+            log.info(">>> Disabling multi-theme build mode <<<")
+            return themes[0]
+        if not hasattr(os, "fork"):
+            log.warning(">>> Platform does not support forking, disabling multi-theme build <<<")
+            return themes[0]
+
+        # Get Sphinx app instance.
+        app = cls.get_sphinx_app()
+        if not app:
+            log.warning(">>> Unable to locate Sphinx app instance from here <<<")
+            return themes[0]
+
+        # Build secondary themes into subdirectories.
+        log.info(">>> Entering multi-theme build mode <<<")
+        for theme in themes[1:]:
+            log.info(">>> Building docs with theme: %s <<<", theme)
+            if cls.fork():
+                cls.modify_sphinx_app(app, theme)
+                return theme  # This is the child process.
+            log.info(">>> Done with theme: %s <<<", theme)
+        log.info(">>> Exiting multi-theme build mode <<<")
+
+        return themes[0]

--- a/tests/unit_tests/test_docs/test-multi-theme/conftest.py
+++ b/tests/unit_tests/test_docs/test-multi-theme/conftest.py
@@ -1,0 +1,12 @@
+"""pytest fixtures."""
+from pathlib import Path
+
+import pytest
+from bs4 import BeautifulSoup
+
+
+@pytest.fixture()
+def hello_html(outdir: Path) -> BeautifulSoup:
+    """Read and parse generated test hello.html."""
+    text = (outdir / "hello.html").read_text(encoding="utf8")
+    return BeautifulSoup(text, "html.parser")

--- a/tests/unit_tests/test_docs/test-multi-theme/single-theme/off/conf.py
+++ b/tests/unit_tests/test_docs/test-multi-theme/single-theme/off/conf.py
@@ -1,0 +1,6 @@
+"""Sphinx test configuration."""
+exclude_patterns = ["_build"]
+extensions = ["sphinx_carousel.carousel"]
+master_doc = "index"
+nitpicky = True
+html_theme = "alabaster"

--- a/tests/unit_tests/test_docs/test-multi-theme/single-theme/off/hello.rst
+++ b/tests/unit_tests/test_docs/test-multi-theme/single-theme/off/hello.rst
@@ -1,0 +1,5 @@
+=====
+Hello
+=====
+
+Hello World!

--- a/tests/unit_tests/test_docs/test-multi-theme/single-theme/off/index.rst
+++ b/tests/unit_tests/test_docs/test-multi-theme/single-theme/off/index.rst
@@ -1,0 +1,11 @@
+====
+Test
+====
+
+Hello World
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Main
+
+    hello

--- a/tests/unit_tests/test_docs/test-multi-theme/single-theme/on/conf.py
+++ b/tests/unit_tests/test_docs/test-multi-theme/single-theme/on/conf.py
@@ -1,0 +1,8 @@
+"""Sphinx test configuration."""
+from sphinx_carousel.unrelated import MultiTheme
+
+exclude_patterns = ["_build"]
+extensions = ["sphinx_carousel.carousel"]
+master_doc = "index"
+nitpicky = True
+html_theme = MultiTheme.select_theme(["alabaster"])

--- a/tests/unit_tests/test_docs/test-multi-theme/single-theme/on/hello.rst
+++ b/tests/unit_tests/test_docs/test-multi-theme/single-theme/on/hello.rst
@@ -1,0 +1,5 @@
+=====
+Hello
+=====
+
+Hello World!

--- a/tests/unit_tests/test_docs/test-multi-theme/single-theme/on/index.rst
+++ b/tests/unit_tests/test_docs/test-multi-theme/single-theme/on/index.rst
@@ -1,0 +1,11 @@
+====
+Test
+====
+
+Hello World
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Main
+
+    hello

--- a/tests/unit_tests/test_docs/test-multi-theme/test_single_theme.py
+++ b/tests/unit_tests/test_docs/test-multi-theme/test_single_theme.py
@@ -1,0 +1,116 @@
+"""Tests."""
+from filecmp import clear_cache, dircmp
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+EXPECTED_NUM_FILES = 27
+ROOTS = ("multi-theme/single-theme/off", "multi-theme/single-theme/on")
+
+
+def directory_compare(left: Optional[Path] = None, right: Optional[Path] = None, compare: Optional[dircmp] = None) -> int:
+    """Recursively compare two directories and their file contents.
+
+    :return: Number of common files found recursively.
+    """
+    clear_cache()
+    if not compare:
+        compare = dircmp(left, right)
+
+    # Verify no errors found by dircmp.
+    assert not compare.funny_files
+    assert not compare.common_funny
+
+    # Verify all non-recursive files/directories in both directories are the same.
+    assert not compare.left_only
+    assert not compare.right_only
+    assert not compare.diff_files
+
+    # Verify file contents.
+    file_count = 0
+    for name in compare.same_files:
+        left_file = Path(compare.left) / name
+        right_file = Path(compare.right) / name
+        assert left_file.read_bytes() == right_file.read_bytes()
+        file_count += 1
+
+    # Recurse.
+    for common_sub_dir in compare.subdirs.values():
+        file_count += directory_compare(compare=common_sub_dir)
+
+    return file_count
+
+
+@pytest.mark.parametrize("testroot", [pytest.param(r, marks=pytest.mark.sphinx("html", testroot=r)) for r in ROOTS])
+def test(outdir: Path, testroot: str):
+    """Verify single-theme is the same as not using this feature."""
+    assert (outdir / "index.html").is_file()
+
+    # Diff all files.
+    if testroot.endswith("on"):
+        parts = outdir.parts
+        idx = parts.index("on")
+        outdir_off = Path(*(parts[:idx] + ("off",) + parts[idx + 1 :]))  # noqa
+        assert directory_compare(outdir, outdir_off) == EXPECTED_NUM_FILES
+
+
+def test_directory_compare(tmp_path: Path):
+    """Sanity checks to verify function works as expected."""
+    left = tmp_path / "left"
+    right = tmp_path / "right"
+
+    def run():
+        return directory_compare(left, right)
+
+    # Setup both directories identically.
+    for path in (left, right):
+        path.mkdir()
+        path.joinpath("one.txt").write_text("One", encoding="utf8")
+        path.joinpath("two.txt").write_text("Two", encoding="utf8")
+        path.joinpath("three.txt").write_text("Three", encoding="utf8")
+        sub_path = path / "sub"
+        sub_path.mkdir()
+        sub_path.joinpath("four.txt").write_text("Four", encoding="utf8")
+    assert run() == 4
+
+    # Extra file.
+    for path in (left, right):
+        path.joinpath("shoe.txt").write_text("Shoe", encoding="utf8")
+        with pytest.raises(AssertionError):
+            run()
+        path.joinpath("shoe.txt").unlink()
+        run()
+
+    # Extra file in subdir.
+    for path in (left, right):
+        sub_path = path / "new"
+        sub_path.mkdir()
+        sub_path.joinpath("buckle.txt").write_text("Buckle", encoding="utf8")
+        with pytest.raises(AssertionError):
+            run()
+        sub_path.joinpath("buckle.txt").unlink()
+        with pytest.raises(AssertionError):
+            run()  # Empty left over directory.
+        sub_path.rmdir()
+        run()
+
+    # Different size file.
+    for path in (left, right):
+        file_ = path.joinpath("one.txt")
+        file_.write_text("Cowabunga", encoding="utf8")
+        with pytest.raises(AssertionError):
+            run()
+        file_.write_text("One", encoding="utf8")
+        run()
+
+    # Same size different contents in a file.
+    for path in (left, right):
+        file_ = path.joinpath("one.txt")
+        old_size = file_.stat().st_size
+        file_.write_text("ONE", encoding="utf8")
+        assert file_.stat().st_size == old_size
+        with pytest.raises(AssertionError):
+            run()
+        file_.write_text("One", encoding="utf8")
+        run()


### PR DESCRIPTION
Fork the Python process when Sphinx is parsing conf.py and change
`html_theme` as well as `outdir` in the child process. The first theme
in the list is the main theme that will be used for the usual
`_build/html/index.html` page, and subsequent themes will be built into
`_build/html/theme_alabaster/index.html` as an example.

For now building with alabaster and classic as the subsequent themes
without inspecting them for CSS issues with sphinx-carousel, that will
be taken care of in the future.

Maybe one day MultiTheme will be a separate library but for now I'm
tossing it into this project until I need to use it for another project.
Since this is kind of hacky and the forking part doesn't work with
`sphinx.testing` I'm disabling some coverage from most of the
`unrelated.py` file. May need to reimplement in the future and make it
less hacky, or suggest additional APIs in sphinx-doc or something.