### PR TITLE
Supporting PyData and Book themes for Sphinx.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
         run: make it
 
       - name: Build docs
+        if: "(matrix.python != '3.6') && (runner.os != 'Windows')"
         run: make docs
 
       - name: Build package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- N/A
+- Supporting PyData and Book themes for Sphinx.
 
 ## [0.0.2] - 2022-05-06
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,9 @@ rst_epilog = f"""
 html_copy_source = False
 html_theme = MultiTheme(
     [
-        Theme("sphinx_rtd_theme", "Read the Docs"),  # https://sphinx-themes.org/sample-sites/sphinx-rtd-theme/
+        Theme("sphinx_rtd_theme", "Read the Docs"),
+        Theme("pydata_sphinx_theme", "PyData Sphinx Theme"),
+        Theme("sphinx_book_theme", "Sphinx Book Theme"),
     ]
 )
 

--- a/docs/native_features.rst
+++ b/docs/native_features.rst
@@ -7,7 +7,7 @@ Below are options that expose native features of Bootstrap carousels.
 Controls
 ========
 
-https://getbootstrap.com/docs/5.1/components/carousel/#with-controls
+`Official documentation for this feature <https://getbootstrap.com/docs/5.1/components/carousel/#with-controls>`__
 
 Display previous and next controls overlayed on top of the carousel by using ``:show_controls:``. Enable this by default with
 :option:`carousel_show_controls`.
@@ -29,7 +29,7 @@ Display previous and next controls overlayed on top of the carousel by using ``:
 Indicators
 ==========
 
-https://getbootstrap.com/docs/5.1/components/carousel/#with-indicators
+`Official documentation for this feature <https://getbootstrap.com/docs/5.1/components/carousel/#with-indicators>`__
 
 Display image indicators overlayed on top of the carousel by using ``:show_indicators:``. Enable this by default with
 :option:`carousel_show_indicators`.
@@ -51,7 +51,7 @@ Display image indicators overlayed on top of the carousel by using ``:show_indic
 Crossfade
 =========
 
-https://getbootstrap.com/docs/5.1/components/carousel/#crossfade
+`Official documentation for this feature <https://getbootstrap.com/docs/5.1/components/carousel/#crossfade>`__
 
 Animate slides with a fade transition instead of a slide by using ``:show_fade:``. Enable this by default with
 :option:`carousel_show_fade`.
@@ -75,7 +75,7 @@ Animate slides with a fade transition instead of a slide by using ``:show_fade:`
 Dark Mode
 =========
 
-https://getbootstrap.com/docs/5.1/components/carousel/#dark-variant
+`Official documentation for this feature <https://getbootstrap.com/docs/5.1/components/carousel/#dark-variant>`__
 
 Show darker :ref:`controls <native_features:Controls>`, :ref:`indicators <native_features:Indicators>`, and captions by using
 ``:show_dark:``. Enable this by default with :option:`carousel_show_dark`.
@@ -88,7 +88,10 @@ Show darker :ref:`controls <native_features:Controls>`, :ref:`indicators <native
     .. image:: https://i.imgur.com/fmJnevTl.jpg
     .. figure:: https://i.imgur.com/fWyn9A2l.jpg
 
-        Hello World
+        Title and Description
+
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+        eiusmod tempor incididunt ut labore et dolore magna aliqua.
 
 .. code-block:: rst
 
@@ -100,7 +103,10 @@ Show darker :ref:`controls <native_features:Controls>`, :ref:`indicators <native
         .. image:: https://i.imgur.com/fmJnevTl.jpg
         .. figure:: https://i.imgur.com/fWyn9A2l.jpg
 
-            Hello World
+            Title and Description
+
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua.
 
 Additional Options
 ==================

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -6,7 +6,12 @@ To use `Bootstrap Carousels <https://getbootstrap.com/docs/4.6/components/carous
 Sphinx directive to define a carousel, and within it use one or more
 `image <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#images>`_ directives or if you want captions
 use one or more `figure <https://docutils.sourceforge.io/docs/ref/rst/directives.html#figure>`_ directives. Below is an
-example carousel using an image and a figure:
+example carousel using an image and a figure.
+
+.. note::
+
+    Captions are hidden on mobile viewports. A workaround is to use
+    :ref:`show_captions_below <extended_features:Captions Below>`.
 
 .. carousel::
     :show_controls:

--- a/poetry-min.lock
+++ b/poetry-min.lock
@@ -557,6 +557,26 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "pydata-sphinx-theme"
+version = "0.8.1"
+description = "Bootstrap-based Sphinx theme from the PyData community"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+beautifulsoup4 = "*"
+docutils = "!=0.17.0"
+packaging = "*"
+sphinx = ">=3.5.4,<5"
+
+[package.extras]
+doc = ["numpydoc", "myst-parser", "pandas", "pytest", "pytest-regressions", "sphinxext-rediraffe", "sphinx-sitemap", "jupyter-sphinx", "plotly", "numpy", "xarray"]
+test = ["pytest", "pydata-sphinx-theme"]
+coverage = ["pytest-cov", "codecov", "pydata-sphinx-theme"]
+dev = ["pyyaml", "pre-commit", "nox", "pydata-sphinx-theme"]
+
+[[package]]
 name = "pydocstyle"
 version = "6.1.1"
 description = "Python docstring style checker"
@@ -813,6 +833,24 @@ sphinx = "*"
 test = ["pytest", "pytest-cov"]
 
 [[package]]
+name = "sphinx-book-theme"
+version = "0.3.2"
+description = "A clean book theme for scientific explanations and documentation with Sphinx"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pydata-sphinx-theme = ">=0.8.0,<0.9.0"
+pyyaml = "*"
+sphinx = ">=3,<5"
+
+[package.extras]
+code_style = ["pre-commit (>=2.7.0,<2.8.0)"]
+doc = ["ablog (>=0.10.13,<0.11.0)", "ipywidgets", "folium", "numpy", "matplotlib", "numpydoc", "myst-nb (>=0.13,<1.0)", "nbclient", "pandas", "plotly", "sphinx (>=4.0,<5.0)", "sphinx-design", "sphinx-copybutton", "sphinx-tabs", "sphinx-togglebutton (>=0.2.1)", "sphinx-thebe (>=0.1.1)", "sphinxcontrib-bibtex (>=2.2,<3.0)", "sphinxcontrib-youtube", "sphinxext-opengraph"]
+test = ["beautifulsoup4 (>=4.6.1,<5)", "coverage", "myst_nb (>=0.13,<1.0)", "pytest (>=6.0.1,<6.1.0)", "pytest-cov", "pytest-regressions (>=2.0.1,<2.1.0)", "sphinx-thebe"]
+
+[[package]]
 name = "sphinx-copybutton"
 version = "0.5.0"
 description = "Add a copy button to each of your code cells."
@@ -1051,7 +1089,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6"
-content-hash = "979d3751d116a3e951f3c6e3067cc62065e0b6c1f3249cd9e578f1ea752fe7c9"
+content-hash = "81648a680f044feb43f69797ce91fd40394dae14bd7a09b977b0667fc3128f48"
 
 [metadata.files]
 alabaster = [
@@ -1449,6 +1487,10 @@ pycodestyle = [
     {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
     {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
 ]
+pydata-sphinx-theme = [
+    {file = "pydata_sphinx_theme-0.8.1-py3-none-any.whl", hash = "sha256:af2c99cb0b43d95247b1563860942ba75d7f1596360594fce510caaf8c4fcc16"},
+    {file = "pydata_sphinx_theme-0.8.1.tar.gz", hash = "sha256:96165702253917ece13dd895e23b96ee6dce422dcc144d560806067852fe1fed"},
+]
 pydocstyle = [
     {file = "pydocstyle-6.1.1-py3-none-any.whl", hash = "sha256:6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4"},
     {file = "pydocstyle-6.1.1.tar.gz", hash = "sha256:1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc"},
@@ -1547,6 +1589,10 @@ sphinx = [
 sphinx-autobuild = [
     {file = "sphinx-autobuild-2021.3.14.tar.gz", hash = "sha256:de1ca3b66e271d2b5b5140c35034c89e47f263f2cd5db302c9217065f7443f05"},
     {file = "sphinx_autobuild-2021.3.14-py3-none-any.whl", hash = "sha256:8fe8cbfdb75db04475232f05187c776f46f6e9e04cacf1e49ce81bdac649ccac"},
+]
+sphinx-book-theme = [
+    {file = "sphinx_book_theme-0.3.2-py3-none-any.whl", hash = "sha256:4aed92f2ed9d27e002eac5dce1daa8eca42dd9e6464811533c569ee156a6f67d"},
+    {file = "sphinx_book_theme-0.3.2.tar.gz", hash = "sha256:182b5657a345f3bbb2c5b86da65db9b47e27de0ab406cda168142768645121f5"},
 ]
 sphinx-copybutton = [
     {file = "sphinx-copybutton-0.5.0.tar.gz", hash = "sha256:a0c059daadd03c27ba750da534a92a63e7a36a7736dcf684f26ee346199787f6"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -558,6 +558,26 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pydata-sphinx-theme"
+version = "0.8.1"
+description = "Bootstrap-based Sphinx theme from the PyData community"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+beautifulsoup4 = "*"
+docutils = "!=0.17.0"
+packaging = "*"
+sphinx = ">=3.5.4,<5"
+
+[package.extras]
+doc = ["numpydoc", "myst-parser", "pandas", "pytest", "pytest-regressions", "sphinxext-rediraffe", "sphinx-sitemap", "jupyter-sphinx", "plotly", "numpy", "xarray"]
+test = ["pytest", "pydata-sphinx-theme"]
+coverage = ["pytest-cov", "codecov", "pydata-sphinx-theme"]
+dev = ["pyyaml", "pre-commit", "nox", "pydata-sphinx-theme"]
+
+[[package]]
 name = "pydocstyle"
 version = "6.1.1"
 description = "Python docstring style checker"
@@ -782,6 +802,24 @@ sphinx = "*"
 
 [package.extras]
 test = ["pytest", "pytest-cov"]
+
+[[package]]
+name = "sphinx-book-theme"
+version = "0.3.2"
+description = "A clean book theme for scientific explanations and documentation with Sphinx"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pydata-sphinx-theme = ">=0.8.0,<0.9.0"
+pyyaml = "*"
+sphinx = ">=3,<5"
+
+[package.extras]
+code_style = ["pre-commit (>=2.7.0,<2.8.0)"]
+doc = ["ablog (>=0.10.13,<0.11.0)", "ipywidgets", "folium", "numpy", "matplotlib", "numpydoc", "myst-nb (>=0.13,<1.0)", "nbclient", "pandas", "plotly", "sphinx (>=4.0,<5.0)", "sphinx-design", "sphinx-copybutton", "sphinx-tabs", "sphinx-togglebutton (>=0.2.1)", "sphinx-thebe (>=0.1.1)", "sphinxcontrib-bibtex (>=2.2,<3.0)", "sphinxcontrib-youtube", "sphinxext-opengraph"]
+test = ["beautifulsoup4 (>=4.6.1,<5)", "coverage", "myst_nb (>=0.13,<1.0)", "pytest (>=6.0.1,<6.1.0)", "pytest-cov", "pytest-regressions (>=2.0.1,<2.1.0)", "sphinx-thebe"]
 
 [[package]]
 name = "sphinx-copybutton"
@@ -1034,7 +1072,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6"
-content-hash = "9ab069aa32ee60fe3cd256e81d0c415f6d1bdcd89d0a3a248e33865584b80252"
+content-hash = "e1d70f615e633bb3c751f7191fe79261898048d5e85053ec5f5db76ff3e536ae"
 
 [metadata.files]
 alabaster = [
@@ -1432,6 +1470,10 @@ pycodestyle = [
     {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
     {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
 ]
+pydata-sphinx-theme = [
+    {file = "pydata_sphinx_theme-0.8.1-py3-none-any.whl", hash = "sha256:af2c99cb0b43d95247b1563860942ba75d7f1596360594fce510caaf8c4fcc16"},
+    {file = "pydata_sphinx_theme-0.8.1.tar.gz", hash = "sha256:96165702253917ece13dd895e23b96ee6dce422dcc144d560806067852fe1fed"},
+]
 pydocstyle = [
     {file = "pydocstyle-6.1.1-py3-none-any.whl", hash = "sha256:6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4"},
     {file = "pydocstyle-6.1.1.tar.gz", hash = "sha256:1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc"},
@@ -1528,6 +1570,10 @@ sphinx = [
 sphinx-autobuild = [
     {file = "sphinx-autobuild-2021.3.14.tar.gz", hash = "sha256:de1ca3b66e271d2b5b5140c35034c89e47f263f2cd5db302c9217065f7443f05"},
     {file = "sphinx_autobuild-2021.3.14-py3-none-any.whl", hash = "sha256:8fe8cbfdb75db04475232f05187c776f46f6e9e04cacf1e49ce81bdac649ccac"},
+]
+sphinx-book-theme = [
+    {file = "sphinx_book_theme-0.3.2-py3-none-any.whl", hash = "sha256:4aed92f2ed9d27e002eac5dce1daa8eca42dd9e6464811533c569ee156a6f67d"},
+    {file = "sphinx_book_theme-0.3.2.tar.gz", hash = "sha256:182b5657a345f3bbb2c5b86da65db9b47e27de0ab406cda168142768645121f5"},
 ]
 sphinx-copybutton = [
     {file = "sphinx-copybutton-0.5.0.tar.gz", hash = "sha256:a0c059daadd03c27ba750da534a92a63e7a36a7736dcf684f26ee346199787f6"},

--- a/pyproject-min.toml
+++ b/pyproject-min.toml
@@ -66,7 +66,9 @@ pytest-cov = "*"
 pytest-icdiff = "*"
 TexSoup = "*"
 # Docs.
+pydata-sphinx-theme = {version = ">=0.8.0", python = ">=3.7"}
 sphinx-autobuild = "*"
+sphinx-book-theme = {version = ">=0.3.2", python = ">=3.7"}
 sphinx-copybutton = "*"
 sphinx-design = {version = "*", python = "^3.6"}
 sphinx-multi-theme = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,9 @@ pytest-cov = "*"
 pytest-icdiff = "*"
 TexSoup = "*"
 # Docs.
+pydata-sphinx-theme = {version = ">=0.8.0", python = ">=3.7"}
 sphinx-autobuild = "*"
+sphinx-book-theme = {version = ">=0.3.2", python = ">=3.7"}
 sphinx-copybutton = "*"
 sphinx-design = {version = "*", python = "^3.6"}
 sphinx-multi-theme = "*"

--- a/sphinx_carousel/_static/carousel-custom.css_t
+++ b/sphinx_carousel/_static/carousel-custom.css_t
@@ -13,6 +13,14 @@
     font-family: var(--bs-font-sans-serif);
 }
 
+.{{ bootstrap_prefix }}carousel h5, .{{ bootstrap_prefix }}carousel p {
+    color: revert;
+}
+
+.{{ bootstrap_prefix }}carousel h5 {
+    font-weight: bold;
+}
+
 :not(.{{ bootstrap_prefix }}carousel-dark) .scc-shadow-control {
     filter:
         drop-shadow(0 0 0.4rem var(--bs-dark))


### PR DESCRIPTION
These themes only support Python 3.7+ and sphinx-multi-theme doesn't
support Windows, so docs won't be built on these platforms.

Fixing caption text color in these themes. They use the h5/p tag
selector to apply colors which takes priority over inherited class CSS
selectors. Working around this by setting `color: revert`. Also
improving styling by setting `<h5>` to bold since only the RTD theme did
it and it looks nice.