### PR TITLE
Fix ReadTheDocs theme margin-bottom.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Supporting PyData and Book themes for Sphinx.
+- Fix RTD theme padding (https://github.com/Robpol86/sphinx-carousel/issues/31)
 
 ## [0.0.2] - 2022-05-06
 

--- a/sphinx_carousel/_static/carousel-custom.css_t
+++ b/sphinx_carousel/_static/carousel-custom.css_t
@@ -1,3 +1,27 @@
+/*
+ * Fix caption text color in PyData/Book Sphinx themes.
+ */
+
+.{{ bootstrap_prefix }}carousel h5, .{{ bootstrap_prefix }}carousel p {
+    color: revert;
+}
+
+.{{ bootstrap_prefix }}carousel h5 {
+    font-weight: bold;
+}
+
+/*
+ * Fix padding in RTD theme: https://github.com/Robpol86/sphinx-carousel/issues/31
+ */
+
+.rst-content section>.{{ bootstrap_prefix }}carousel {
+    margin-bottom: 24px
+}
+
+/*
+ * Buttons on top.
+ */
+
 .scc-top-control {
     align-items: start;
 }
@@ -13,13 +37,9 @@
     font-family: var(--bs-font-sans-serif);
 }
 
-.{{ bootstrap_prefix }}carousel h5, .{{ bootstrap_prefix }}carousel p {
-    color: revert;
-}
-
-.{{ bootstrap_prefix }}carousel h5 {
-    font-weight: bold;
-}
+/*
+ * Shadows.
+ */
 
 :not(.{{ bootstrap_prefix }}carousel-dark) .scc-shadow-control {
     filter:


### PR DESCRIPTION
Make it the same as img.

Also sorting and adding section comments to css_t file.

Fixes https://github.com/Robpol86/sphinx-carousel/issues/31