### PR TITLE
Declare the plugin as parallel read safe

### DIFF
--- a/sphinx_carousel/carousel.py
+++ b/sphinx_carousel/carousel.py
@@ -91,4 +91,4 @@ def setup(app: Sphinx) -> Dict[str, str]:
     nodes.CarouselInnerNode.add_node(app)
     nodes.CarouselItemNode.add_node(app)
     nodes.CarouselMainNode.add_node(app)
-    return dict(version=__version__)
+    return dict(version=__version__, parallel_read_safe=True)


### PR DESCRIPTION
This is required to prevent a warning when building a sphinx project using this plugin in parallel mode (using `--jobs`), which can be an issue when one run the build process with the `-W` as well (making this warning an error).